### PR TITLE
Replace gammaln with non-NR double precision version

### DIFF
--- a/src/msctools/mscdisplay/src/gamma.x
+++ b/src/msctools/mscdisplay/src/gamma.x
@@ -92,10 +92,10 @@ double	result
 double	gln, ap, sum, del
 int	n
 
-double	gammln()
+double	dgammln()
 
 begin	
-	gln = gammln (a)
+	gln = dgammln (a)
 	if (x <= 0.0d0) {
 	    if (x < 0.0d0)
 		call error (0, "GSER -- X must be non-negative")
@@ -135,11 +135,11 @@ double	result
 double	gln, gold, g, an, ana, a0, a1, b0, b1, fac, anf
 int	n
 
-double	gammln()
+double	dgammln()
 
 begin
 
-	gln = gammln (a)
+	gln = dgammln (a)
 	gold = 0.0d0
 	a0   = 1.0d0
 	a1   = x
@@ -173,31 +173,4 @@ begin
 
 	result = g * exp (-x + a * log(x) - gln)
 	return (result)
-end
-
-# GAMMLN -- Return natural log of gamma function.
-# Argument must greater than 0.  Full accuracy is obtained for values
-# greater than 1.  For 0<xx<1, the reflection formula can be used first.
-#
-#
-
-double procedure gammln (xx)
-
-double  xx              # Value to be evaluated
-
-int     j
-double  cof[6], stp, x, tmp, ser
-data    cof, stp / 76.18009173D0, -86.50532033D0, 24.01409822D0,
-                -1.231739516D0,.120858003D-2,-.536382D-5,2.50662827465D0/
-
-begin
-        x = xx - 1.0D0
-        tmp = x + 5.5D0
-        tmp = (x + 0.5D0) * log (tmp) - tmp
-        ser = 1.0D0
-        do j = 1, 6 {
-            x = x + 1.0D0
-            ser = ser + cof[j] / x
-        }
-        return (tmp + log (stp * ser))
 end

--- a/src/msctools/mscdisplay/src/gammln.c
+++ b/src/msctools/mscdisplay/src/gammln.c
@@ -1,0 +1,22 @@
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+*/
+
+#include <math.h>
+
+double lgamma (double x);
+float lgammaf (float x);
+
+
+/* GAMMLN -- Return natural log of gamma function.
+ * Argument must greater than 0.
+ */
+
+float gammln_ (float *x)
+{
+        return lgammaf (*x);
+}
+
+double dgammn_ (double *x)
+{
+        return lgamma (*x);
+}

--- a/src/msctools/mscdisplay/src/mkpkg
+++ b/src/msctools/mscdisplay/src/mkpkg
@@ -35,6 +35,7 @@ libpkg.a:
 	akavg.x		<mach.h>
 	ampset.x	ampinfo.com <ctotok.h> <error.h>
 	gamma.x		<mach.h>
+	gammln.c
 	linebias.x	lbias.com mosgeom.h
 	maskcolor.x	ace.h <ctotok.h> <evvexpr.h>
 	maxmin.x	<imhdr.h> <mach.h> mosgeom.h


### PR DESCRIPTION
This slipped through our code review.

Taken from https://github.com/noirlab-iraf/nfextern/commit/3dfc497e09d2a3fecf808f38612c66c39d225073
Thanks to @mjfitzpatrick.

There is no **dgammln** function yet available, so this cannot be merged yet. Maybe this was "somehow" done in NOIRLABs IRAF version. Community IRAF uses [a C function for **gammln**](https://github.com/iraf-community/iraf/blob/main/pkg/xtools/gammln.c).